### PR TITLE
fix bug in class CmdPacket and RMDevice

### DIFF
--- a/src/main/java/com/github/mob41/blapi/BLDevice.java
+++ b/src/main/java/com/github/mob41/blapi/BLDevice.java
@@ -753,7 +753,7 @@ public abstract class BLDevice implements Closeable{
         log.debug("DESTIP: " + destIpAddr.getHostAddress());
         log.debug("DESTPORT: " + destPort);
         DatagramPacket sendpack = new DatagramPacket(data, data.length, destIpAddr, destPort);
-        sock.send(sendpack);
+        //sock.send(sendpack);
 
         byte[] rece = new byte[bufSize];
         DatagramPacket recepack = new DatagramPacket(rece, 0, rece.length);

--- a/src/main/java/com/github/mob41/blapi/RMDevice.java
+++ b/src/main/java/com/github/mob41/blapi/RMDevice.java
@@ -31,6 +31,7 @@ package com.github.mob41.blapi;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
+import java.util.Arrays;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -132,7 +133,7 @@ public class RMDevice extends BLDevice {
             }
 
         });
-        byte[] data = packet.getData();
+        byte[] data = Arrays.copyOf(packet.getData(), packet.getLength());
 
         log.debug("Packet received bytes: " + DatatypeConverter.printHexBinary(data));
 
@@ -140,7 +141,7 @@ public class RMDevice extends BLDevice {
 
         if (err == 0){
             AES aes = new AES(getIv(), getKey());
-            byte[] pl = aes.decrypt(data);
+            byte[] pl = aes.decrypt(Arrays.copyOfRange(data, 0x38, data.length));
             return (double) (pl[0x4] * 10 + pl[0x5]) / 10.0;
         } else {
             log.warn("Received an error: " + Integer.toHexString(err) + " / " + err);

--- a/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
+++ b/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
@@ -108,6 +108,12 @@ public class CmdPacket implements Packet {
 
         log.debug("Running checksum for headers");
 
+		/* The program is ported from python.
+		 * Byte in python in the range is 0 to 256, but in java, it is in the range of -128 to 127.
+		 * Here is a judgment to ensure that payload[i] is a positive number and checksum is aways growing.         *         * 
+		 *  
+		 * The same problem exists in data[0x20] and data[0x21], but it does not affect the execution of the program.
+		 */
         int checksum = 0xbeaf;
         for (int i = 0; i < payload.length; i++){
             checksum += payload[i];

--- a/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
+++ b/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
@@ -116,7 +116,11 @@ public class CmdPacket implements Packet {
 		 */
         int checksum = 0xbeaf;
         for (int i = 0; i < payload.length; i++){
-            checksum += payload[i];
+        	if(payload[i]>=0){
+                checksum += payload[i];
+        	}else{
+                checksum += 256+payload[i];        		
+        	}
             checksum &= 0xffff;
         }
 


### PR DESCRIPTION
1. CmdPacket‘s constructor
fix a bug which is because of porting from python to java …The program is ported from python. Byte in python in the range is 0 to 256, but in java, it is in the range of -128 to 127. Adding a judgment to ensure that payload[i] is a positive number and checksum is aways growing.

2. RMDevice's getTemp()
Payload is from 0x38 of data