### PR TITLE
Add support for Mini 3

### DIFF
--- a/src/main/java/com/github/mob41/blapi/BLDevice.java
+++ b/src/main/java/com/github/mob41/blapi/BLDevice.java
@@ -108,6 +108,8 @@ public abstract class BLDevice implements Closeable {
 
     public static final short DEV_RM_MINI = 0x2737;
 
+    public static final short DEV_RM_MINI_3 = 0x27c2;
+
     public static final short DEV_RM_PRO_PHICOMM = 0x273d;
 
     public static final short DEV_RM_2_HOME_PLUS = 0x2783;
@@ -145,6 +147,8 @@ public abstract class BLDevice implements Closeable {
     public static final String DESC_RM_2 = "RM 2";
 
     public static final String DESC_RM_MINI = "RM Mini";
+
+    public static final String DESC_RM_MINI_3 = "RM Mini 3";
 
     public static final String DESC_RM_PRO_PHICOMM = "RM Pro";
 
@@ -562,6 +566,8 @@ public abstract class BLDevice implements Closeable {
             return new SP2Device(deviceType, desc, host, mac);
         case DEV_RM_2:
         case DEV_RM_MINI:
+        case DEV_RM_MINI_3:
+            return new RM2Device(deviceType, desc, host, mac);
         case DEV_RM_PRO_PHICOMM:
         case DEV_RM_2_HOME_PLUS:
         case DEV_RM_2_2HOME_PLUS_GDT:
@@ -760,6 +766,8 @@ public abstract class BLDevice implements Closeable {
             return DESC_RM_2;
         case BLDevice.DEV_RM_MINI:
             return DESC_RM_MINI;
+        case BLDevice.DEV_RM_MINI_3:
+            return DESC_RM_MINI_3;
         case BLDevice.DEV_RM_PRO_PHICOMM:
             return DESC_RM_PRO_PHICOMM;
         case BLDevice.DEV_RM_2_HOME_PLUS:

--- a/src/test/java/com/github/mob41/blapi/DevicesTest.java
+++ b/src/test/java/com/github/mob41/blapi/DevicesTest.java
@@ -86,6 +86,7 @@ public class DevicesTest {
 				break;
 			case BLDevice.DEV_RM_2:
 			case BLDevice.DEV_RM_MINI:
+			case BLDevice.DEV_RM_MINI_3:
 			case BLDevice.DEV_RM_PRO_PHICOMM:
 			case BLDevice.DEV_RM_2_HOME_PLUS:
 			case BLDevice.DEV_RM_2_2HOME_PLUS_GDT:


### PR DESCRIPTION
Just a quick change to add support for the mini3 RM2 style device. 

I'm not sure why, but on saving the newline char seems to have changed in places, however the formatting remains unchanged. I hope this isn't a problem!