### PR TITLE
Android changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .project
 .settings/
+.idea
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - .travis/prepare
 
 script:
-- mvn cobertura:cobertura
+- mvn clean test
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
       		<groupId>org.apache.maven.plugins</groupId>
        		<artifactId>maven-javadoc-plugin</artifactId>
        		<version>2.9.1</version>
-       		<configuration> ^M
-       			<source>8</source> ^M
-       		</configuration>^M
+       		<configuration>
+       			<source>8</source>
+       		</configuration>
        		<executions>
          		<execution>
            		<id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,9 @@
       		<groupId>org.apache.maven.plugins</groupId>
        		<artifactId>maven-javadoc-plugin</artifactId>
        		<version>2.9.1</version>
+       		<configuration> ^M
+       			<source>8</source> ^M
+       		</configuration>^M
        		<executions>
          		<execution>
            		<id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -142,19 +142,26 @@
         		</execution>
       		</executions>
     	</plugin>
-    	<plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-maven-plugin</artifactId>
-            <version>2.7</version>
-            <configuration>
-                <formats>
-                    <format>html</format>
-                    <format>xml</format>
-                </formats>
-                <check />
-            </configuration>
+        <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.5</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>test</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
         </plugin>
-   	</plugins>
+    </plugins>
   </build>
 	
   <version>1.0.1</version>

--- a/src/main/java/com/github/mob41/blapi/A1Device.java
+++ b/src/main/java/com/github/mob41/blapi/A1Device.java
@@ -31,7 +31,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.CmdPayload;
@@ -68,13 +68,13 @@ public class A1Device extends BLDevice {
         });
         byte[] data = packet.getData();
 
-        log.debug("A1 check sensors received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("A1 check sensors received encrypted bytes: " + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = decryptFromDeviceMessage(data);
-            log.debug("A1 check sensors received bytes (decrypted):" + DatatypeConverter.printHexBinary(pl));
+            log.debug("A1 check sensors received bytes (decrypted):" + bytes2hex(pl));
 
             float temp = (float) ((pl[0x4] * 10 + pl[0x5]) / 10.0);
             float hum = (float) ((pl[0x6] * 10 + pl[0x7]) / 10.0);

--- a/src/main/java/com/github/mob41/blapi/BLDevice.java
+++ b/src/main/java/com/github/mob41/blapi/BLDevice.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -389,7 +389,7 @@ public abstract class BLDevice implements Closeable {
         log.debug("auth Sending CmdPacket with AuthCmdPayload: cmd=" + Integer.toHexString(sendPayload.getCommand())
                     + " len=" + sendPayload.getPayload().getData().length);
 
-        log.debug("auth AuthPayload initial bytes to send: {}", DatatypeConverter.printHexBinary(sendPayload.getPayload().getData()));
+        log.debug("auth AuthPayload initial bytes to send: {}", bytes2hex(sendPayload.getPayload().getData()));
 
         DatagramPacket recvPack = sendCmdPkt(10000, 2048, sendPayload);
 
@@ -401,7 +401,7 @@ public abstract class BLDevice implements Closeable {
             return false;
         }
 
-        log.debug("auth recv encrypted data bytes (" + data.length +") after initial req: {}", DatatypeConverter.printHexBinary(data));
+        log.debug("auth recv encrypted data bytes (" + data.length +") after initial req: {}", bytes2hex(data));
 
         byte[] payload = null;
         try {
@@ -417,11 +417,11 @@ public abstract class BLDevice implements Closeable {
             return false;
         }
 
-        log.debug("auth Packet received payload bytes: " + DatatypeConverter.printHexBinary(payload));
+        log.debug("auth Packet received payload bytes: " + bytes2hex(payload));
 
         key = subbytes(payload, 0x04, 0x14);
 
-        log.debug("auth Packet received key bytes: " + DatatypeConverter.printHexBinary(key));
+        log.debug("auth Packet received key bytes: " + bytes2hex(key));
 
         if (key.length % 16 != 0) {
             log.error("auth Received key len is not a multiple of 16! Aborting");
@@ -434,7 +434,7 @@ public abstract class BLDevice implements Closeable {
 
         id = subbytes(payload, 0x00, 0x04);
 
-        log.debug("auth Packet received id bytes: " + DatatypeConverter.printHexBinary(id) + " with ID len=" + id.length);
+        log.debug("auth Packet received id bytes: " + bytes2hex(id) + " with ID len=" + id.length);
 
         log.debug("auth End of authentication method");
         alreadyAuthorized = true;
@@ -530,7 +530,7 @@ public abstract class BLDevice implements Closeable {
     public DatagramPacket sendCmdPkt(InetAddress sourceIpAddr, int sourcePort, int timeout, int bufSize,
             CmdPayload cmdPayload) throws IOException {
         CmdPacket cmdPkt = new CmdPacket(mac, pktCount++, id, aes, cmdPayload);
-        log.debug("sendCmdPkt - Send Command Packet bytes: {}", DatatypeConverter.printHexBinary(cmdPkt.getData()));
+        log.debug("sendCmdPkt - Send Command Packet bytes: {}", bytes2hex(cmdPkt.getData()));
         return sendPkt(sock, cmdPkt, InetAddress.getByName(host), 80, timeout, bufSize);
     }
 
@@ -1041,7 +1041,7 @@ public abstract class BLDevice implements Closeable {
             }
         }
 
-        log.debug("sendPkt - recv data bytes (" + recepack.getData().length +") after initial req: {}", DatatypeConverter.printHexBinary(recepack.getData()));
+        log.debug("sendPkt - recv data bytes (" + recepack.getData().length +") after initial req: {}", bytes2hex(recepack.getData()));
         recepack.setData(removeNullsFromEnd(recepack.getData(), 0));
         return recepack;
     }

--- a/src/main/java/com/github/mob41/blapi/HexUtil.java
+++ b/src/main/java/com/github/mob41/blapi/HexUtil.java
@@ -1,0 +1,30 @@
+package com.github.mob41.blapi;
+
+public class HexUtil {
+
+    private static final char[] hexCode = "0123456789abcdef".toCharArray();
+
+    public static String bytes2hex(byte[] data) {
+        StringBuilder r = new StringBuilder(data.length * 2);
+        byte[] var3 = data;
+        int var4 = data.length;
+
+        for(int var5 = 0; var5 < var4; ++var5) {
+            byte b = var3[var5];
+            r.append(hexCode[b >> 4 & 15]);
+            r.append(hexCode[b & 15]);
+        }
+
+        return r.toString();
+    }
+    public static final byte[] hex2bytes(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
+}

--- a/src/main/java/com/github/mob41/blapi/MP1Device.java
+++ b/src/main/java/com/github/mob41/blapi/MP1Device.java
@@ -32,7 +32,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.CmdPayload;
@@ -116,7 +116,7 @@ public class MP1Device extends BLDevice {
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
-        	log.debug("MP1 set state mask received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+            log.debug("MP1 set state mask received encrypted bytes: " + bytes2hex(data));
         } else {
             log.warn("MP1 set state mask received returned err: " + Integer.toHexString(err) + " / " + err);        	
         }
@@ -171,13 +171,13 @@ public class MP1Device extends BLDevice {
 
         byte[] data = packet.getData();
 
-        log.debug("MP1 get states raw received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("MP1 get states raw received encrypted bytes: " + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = decryptFromDeviceMessage(data);
-            log.debug("MP1 get states raw received bytes (decrypted): " + DatatypeConverter.printHexBinary(pl));
+            log.debug("MP1 get states raw received bytes (decrypted): " + bytes2hex(pl));
             byte state = 0;
             if (pl[0x3c] >= 48 && pl[0x3c] <= 57) {
                 String decodeValue1;

--- a/src/main/java/com/github/mob41/blapi/RM2Device.java
+++ b/src/main/java/com/github/mob41/blapi/RM2Device.java
@@ -31,7 +31,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import static com.github.mob41.blapi.HexUtil.bytes2hex;
+import com.github.mob41.blapi.HexUtil;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.cmd.rm2.CheckDataCmdPayload;
@@ -88,7 +88,7 @@ public class RM2Device extends BLDevice {
 
         int err = data[0x22] | (data[0x23] << 8);
 
-        log.debug("RM2 check data received encrypted bytes: " + bytes2hex(data));
+        log.debug("RM2 check data received encrypted bytes: " + HexUtil.bytes2hex(data));
 
 
         if (err == 0) {
@@ -115,7 +115,7 @@ public class RM2Device extends BLDevice {
 		DatagramPacket packet = sendCmdPkt(10000, cmdPayload);
 
         byte[] data = packet.getData();
-        log.debug("RM2 enter learning received encrypted bytes: " + bytes2hex(data));
+        log.debug("RM2 enter learning received encrypted bytes: " + HexUtil.bytes2hex(data));
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
@@ -139,12 +139,12 @@ public class RM2Device extends BLDevice {
         DatagramPacket packet = sendCmdPkt(new RMTempCmdPayload());
         byte[] data = packet.getData();
 
-        log.debug("RM2 get temp received encrypted bytes: " + bytes2hex(data));
+        log.debug("RM2 get temp received encrypted bytes: " + HexUtil.bytes2hex(data));
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = decryptFromDeviceMessage(data);
-            log.debug("RM2 get temp received bytes (decrypted): " + bytes2hex(pl));
+            log.debug("RM2 get temp received bytes (decrypted): " + HexUtil.bytes2hex(pl));
 
             return (double) (pl[0x4] * 10 + pl[0x5]) / 10.0;
         } else {

--- a/src/main/java/com/github/mob41/blapi/RM2Device.java
+++ b/src/main/java/com/github/mob41/blapi/RM2Device.java
@@ -31,7 +31,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.cmd.rm2.CheckDataCmdPayload;
@@ -88,7 +88,7 @@ public class RM2Device extends BLDevice {
 
         int err = data[0x22] | (data[0x23] << 8);
 
-        log.debug("RM2 check data received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("RM2 check data received encrypted bytes: " + bytes2hex(data));
 
 
         if (err == 0) {
@@ -115,7 +115,7 @@ public class RM2Device extends BLDevice {
 		DatagramPacket packet = sendCmdPkt(10000, cmdPayload);
 
         byte[] data = packet.getData();
-        log.debug("RM2 enter learning received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("RM2 enter learning received encrypted bytes: " + bytes2hex(data));
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
@@ -139,12 +139,12 @@ public class RM2Device extends BLDevice {
         DatagramPacket packet = sendCmdPkt(new RMTempCmdPayload());
         byte[] data = packet.getData();
 
-        log.debug("RM2 get temp received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("RM2 get temp received encrypted bytes: " + bytes2hex(data));
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = decryptFromDeviceMessage(data);
-            log.debug("RM2 get temp received bytes (decrypted): " + DatatypeConverter.printHexBinary(pl));
+            log.debug("RM2 get temp received bytes (decrypted): " + bytes2hex(pl));
 
             return (double) (pl[0x4] * 10 + pl[0x5]) / 10.0;
         } else {

--- a/src/main/java/com/github/mob41/blapi/SP1Device.java
+++ b/src/main/java/com/github/mob41/blapi/SP1Device.java
@@ -32,7 +32,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.CmdPayload;
@@ -70,7 +70,7 @@ public class SP1Device extends BLDevice {
 
         byte[] data = packet.getData();
 
-        log.debug("SP1 set power received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("SP1 set power received encrypted bytes: " + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 

--- a/src/main/java/com/github/mob41/blapi/SP2Device.java
+++ b/src/main/java/com/github/mob41/blapi/SP2Device.java
@@ -32,7 +32,7 @@ package com.github.mob41.blapi;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.CmdPayload;
@@ -75,7 +75,7 @@ public class SP2Device extends BLDevice {
 
         byte[] data = packet.getData();
 
-        log.debug("SP2 set state received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("SP2 set state received encrypted bytes: " + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 
@@ -109,13 +109,13 @@ public class SP2Device extends BLDevice {
         });
         byte[] data = packet.getData();
 
-        log.debug("SP2 get state received encrypted bytes: " + DatatypeConverter.printHexBinary(data));
+        log.debug("SP2 get state received encrypted bytes: " + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = decryptFromDeviceMessage(data);
-            log.debug("SP2 get state  received bytes (decrypted): " + DatatypeConverter.printHexBinary(pl));
+            log.debug("SP2 get state  received bytes (decrypted): " + bytes2hex(pl));
             return pl[0x4] == 1 ? true : false;
         } else {
             log.warn("SP2 get state received an error: " + Integer.toHexString(err) + " / " + err);

--- a/src/main/java/com/github/mob41/blapi/dev/hysen/BaseHysenDevice.java
+++ b/src/main/java/com/github/mob41/blapi/dev/hysen/BaseHysenDevice.java
@@ -31,7 +31,7 @@ package com.github.mob41.blapi.dev.hysen;
 
 import java.io.IOException;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import com.github.mob41.blapi.BLDevice;
 import com.github.mob41.blapi.mac.Mac;
@@ -92,7 +92,7 @@ public class BaseHysenDevice extends BLDevice {
     public BaseStatusInfo getBasicStatus() throws Exception {
         byte[] pl = new GetBasicInfoCommand().execute(this);
         if (pl != null) {
-            log.debug("getBasicStatus - received bytes: {}", DatatypeConverter.printHexBinary(pl));
+            log.debug("getBasicStatus - received bytes: {}", bytes2hex(pl));
             return new BaseStatusInfo(pl);
         }
         return null;
@@ -101,7 +101,7 @@ public class BaseHysenDevice extends BLDevice {
     public AdvancedStatusInfo getAdvancedStatus() throws Exception {
         byte[] pl = new GetStatusCommand().execute(this);
         if (pl != null) {
-            log.debug("getAdvancedStatus - received bytes: {}", DatatypeConverter.printHexBinary(pl));
+            log.debug("getAdvancedStatus - received bytes: {}", bytes2hex(pl));
             return new AdvancedStatusInfo(pl);
         }
         return null;

--- a/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
+++ b/src/main/java/com/github/mob41/blapi/pkt/CmdPacket.java
@@ -28,8 +28,6 @@
  *******************************************************************************/
 package com.github.mob41.blapi.pkt;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +35,7 @@ import com.github.mob41.blapi.BLDevice;
 import com.github.mob41.blapi.ex.BLApiRuntimeException;
 import com.github.mob41.blapi.mac.Mac;
 import com.github.mob41.blapi.pkt.auth.AES;
-
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 /**
  * This constructs a byte array with the format of a command to the Broadlink
  * device
@@ -133,7 +131,7 @@ public class CmdPacket implements Packet {
 
         int checksumpayload = 0xbeaf;
         for (int i = 0; i < payloadPad.length; i++) {
-            checksumpayload = checksumpayload + Byte.toUnsignedInt(payloadPad[i]);
+            checksumpayload = checksumpayload + (int)(Byte.valueOf(payloadPad[i]).intValue() & 0xff);
             checksumpayload = checksumpayload & 0xffff;
         }
 
@@ -146,7 +144,7 @@ public class CmdPacket implements Packet {
             log.debug("Encrypting payload");
 
             payload = aesInstance.encrypt(payloadPad);
-            log.debug("Encrypted payload bytes: {}", DatatypeConverter.printHexBinary(payload));
+            log.debug("Encrypted payload bytes: {}", bytes2hex(payload));
 
             log.debug("Encrypted. len=" + payload.length);
         } catch (Exception e) {
@@ -168,7 +166,7 @@ public class CmdPacket implements Packet {
 
         int checksumpkt = 0xbeaf;
         for (int i = 0; i < data.length; i++) {
-            checksumpkt = checksumpkt + Byte.toUnsignedInt(data[i]);
+            checksumpkt = checksumpkt + (int)(Byte.valueOf(data[i]).intValue() & 0xff);
             checksumpkt = checksumpkt & 0xffff;
 //            log.debug("index: " + i + ", data byte: " + Byte.toUnsignedInt(data[i]) + ", checksum: " + checksumpkt);
         }

--- a/src/main/java/com/github/mob41/blapi/pkt/cmd/hysen/BaseHysenCommand.java
+++ b/src/main/java/com/github/mob41/blapi/pkt/cmd/hysen/BaseHysenCommand.java
@@ -3,7 +3,7 @@ package com.github.mob41.blapi.pkt.cmd.hysen;
 import java.net.DatagramPacket;
 import java.util.Arrays;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.github.mob41.blapi.HexUtil.bytes2hex;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,14 +33,14 @@ public abstract class BaseHysenCommand implements CmdPayload {
         byte[] data = packet.getData();
 
         log.debug(this.getClass().getSimpleName() + " received encrypted bytes: "
-                + DatatypeConverter.printHexBinary(data));
+                + bytes2hex(data));
 
         int err = data[0x22] | (data[0x23] << 8);
 
         if (err == 0) {
             byte[] pl = device.decryptFromDeviceMessage(data);
             log.debug(this.getClass().getSimpleName() + " received bytes (decrypted): "
-                    + DatatypeConverter.printHexBinary(pl));
+                    + bytes2hex(pl));
             return Arrays.copyOfRange(pl, 2, pl.length);
         } else {
             log.warn(this.getClass().getSimpleName() + " received an error: " + Integer.toHexString(err) + " / " + err);


### PR DESCRIPTION
To run on older android devices, I needed to remove references to Byte.toUnsignedInt and newer javas also don't ship with javax.xml anymore, so I also removed javax.xml.bind.DatatypeConverter which was only used for bytes -> hex conversion and replaced with a HexUtil class that can do the conversion both ways.